### PR TITLE
Bugfix: Task editor stuck in loading state

### DIFF
--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -75,7 +75,7 @@ export default function Task() {
   const { isOpen, onOpen, onClose } = useDisclosure()
   const { isAssistant, user } = useOutletContext<UserContext>()
   const [taskId, setTaskId] = useState(-1)
-  const [submissionId, setSubmissionId] = useState(0)
+  const [submissionId, setSubmissionId] = useState<number | null>(null)
   const [currentTab, setCurrentTab] = useState(0)
   const [currentFile, setCurrentFile] = useState<TaskFileProps>()
   const [editableFiles, setEditableFiles] = useState<TaskFileProps[]>([])
@@ -110,7 +110,7 @@ export default function Task() {
 
   useEffect(() => {
     if (task) {
-      if (submissionId == -1) {
+      if (submissionId == -1 || submissionId == null) {
         const defaultFiles = task.files.filter((file) => file.editable)
         setEditableFiles(defaultFiles)
       } else {
@@ -124,7 +124,6 @@ export default function Task() {
       }
     }
   }, [submissionId])
-
   useEffect(() => {
     if (task) {
       if (currentFile == undefined || taskId != task.id) {
@@ -135,8 +134,8 @@ export default function Task() {
           unionBy(
             files,
             files.map((file) => find(editableFiles, { id: file.id }) || file),
-            "id"
-          )
+            "id",
+          ),
         )
         setCurrentFile((file) => file && find(editableFiles, { id: file.id }))
       }
@@ -213,7 +212,7 @@ export default function Task() {
     task.information[currentLanguage]?.instructionsFile ||
     task.information["en"].instructionsFile
   const instructionsContent = task.files.filter(
-    (file) => file.path === `/${instructionFile}`
+    (file) => file.path === `/${instructionFile}`,
   )[0]?.template
 
   return (
@@ -361,11 +360,11 @@ export default function Task() {
                       .forEach((file) =>
                         zip.file(
                           `${task.slug}${file.path}`,
-                          file.template || file.templateBinary
-                        )
+                          file.template || file.templateBinary,
+                        ),
                       )
                     editableFiles.forEach((file) =>
-                      zip.file(`${task.slug}${file.path}`, getContent(file))
+                      zip.file(`${task.slug}${file.path}`, getContent(file)),
                     )
                     zip
                       .generateAsync({ type: "blob" })
@@ -460,7 +459,7 @@ export default function Task() {
                           <Code fontWeight={700} whiteSpace="pre-wrap">
                             {submissionName(
                               submission.command,
-                              submission.ordinalNum
+                              submission.ordinalNum,
                             )}
                           </Code>
                         </HStack>
@@ -623,13 +622,13 @@ export default function Task() {
                       <Text lineHeight={1.2} fontWeight={500}>
                         {submissionName(
                           submission.command,
-                          submission.ordinalNum
+                          submission.ordinalNum,
                         )}
                       </Text>
                       <Text fontSize="2xs">
                         {format(
                           parseISO(submission.createdAt),
-                          "dd.MM.yyyy HH:mm"
+                          "dd.MM.yyyy HH:mm",
                         )}
                       </Text>
                       {!submission.valid && (


### PR DESCRIPTION
### Bug 

While testing if example tasks can be submitted, I stumbled across the following bug:

Sometimes, if I tried to access a task for which I submitted a solution, the task editor would be stuck in a loading state. If I refreshed the page, the task would then correctly load. 

As I wasn't sure if this bug was newly introduced by some error I made, I checked if this also a problem on the main branch or not. And indeed it also seemed to occur on the main branch. 

### Root Cause

The problem seems to lie in how `submissionId` is set and used across multiple `useEffect` hooks in `Task.tsx`, which can lead to race conditions:

1. `submissionId` is initialized to `0` (line 78).
2. The first `useEffect` (line 91) detects an existing submission and sets both `submissionId` and `editableFiles`.
3. When the second `useEffect` (line 111) runs,  as states are not necessarily updated synchronously,it can happen that its still using the outdated `submissionId = 0`, resulting in no matching submission being found.
4. This causes `editableFiles` to be set to an empty array.
5. As a later result, `currentFile` becomes `undefined`, and the app falls back to rendering `<Placeholder>` (line 152), and gets stuck in that state. 


To make things more clear, I suggest initializing `submissionId` as `null`. By extending the condition on line 113 with this null check, `editableFiles` will not be set while `submissionId` still holds the initial null state. 

Obviously, the way it was implemented seemed to work most of the time, but somehow at least in the dev environment, this bug could appear and the general behavior is quite flaky. I hope this fix eliminates that.