### PR TITLE
Timer countdown enhancements

### DIFF
--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -37,14 +37,21 @@ export const CountdownTimer: React.FC<{
 
     return "red.500"
   }, [timeLeftInSeconds, totalTimeInSeconds])
-
   return (
     <CircularProgress
       size={sizeMap[size]}
       value={circleValue}
       color={dynamicColor}
     >
-      <CircularProgressLabel>{remainingTimeString}</CircularProgressLabel>
+      <CircularProgressLabel
+        style={{
+          fontVariantNumeric: "tabular-nums",
+          fontFamily: "monospace",
+        }}
+        fontSize={size === "large" ? "4xl" : size === "medium" ? "2xl" : "md"}
+      >
+        {remainingTimeString}
+      </CircularProgressLabel>
     </CircularProgress>
   )
 }

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -28,10 +28,10 @@ export const CountdownTimer: React.FC<{
   }, [timeLeftInSeconds, totalTimeInSeconds])
 
   const dynamicColor = useMemo(() => {
-    if (timeLeftInSeconds > totalTimeInSeconds / 3) {
+    if (timeLeftInSeconds > Math.min(totalTimeInSeconds / 3, 30)) {
       return "green.500"
     }
-    if (timeLeftInSeconds > totalTimeInSeconds / 10) {
+    if (timeLeftInSeconds > 10) {
       return "orange.200"
     }
 

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -16,16 +16,12 @@ export const CountdownTimer: React.FC<{
   endTime: number | null
   size: SizeKey
 }> = ({ startTime, endTime, size }) => {
-  const { timeLeftInSeconds } = useCountdown(startTime ?? 0, endTime ?? 0)
+  const { timeLeftInSeconds, circleValue } = useCountdown(
+    startTime ?? 0,
+    endTime ?? 0,
+  )
   const totalTimeInSeconds = ((endTime ?? 0) - (startTime ?? 0)) / 1000
   const remainingTimeString = formatSeconds(timeLeftInSeconds)
-
-  const circleValue = useMemo(() => {
-    if (totalTimeInSeconds <= 0) {
-      return 0
-    }
-    return (timeLeftInSeconds / totalTimeInSeconds) * 100
-  }, [timeLeftInSeconds, totalTimeInSeconds])
 
   const dynamicColor = useMemo(() => {
     if (timeLeftInSeconds > Math.min(totalTimeInSeconds / 3, 30)) {
@@ -48,7 +44,7 @@ export const CountdownTimer: React.FC<{
           fontVariantNumeric: "tabular-nums",
           fontFamily: "monospace",
         }}
-        fontSize={size === "large" ? "4xl" : size === "medium" ? "2xl" : "md"}
+        fontSize={size === "large" ? "3xl" : size === "medium" ? "2xl" : "md"}
       >
         {remainingTimeString}
       </CircularProgressLabel>

--- a/src/components/CountdownTimer.tsx
+++ b/src/components/CountdownTimer.tsx
@@ -32,10 +32,10 @@ export const CountdownTimer: React.FC<{
       return "green.500"
     }
     if (timeLeftInSeconds > totalTimeInSeconds / 10) {
-      return "yellow.500"
+      return "orange.200"
     }
 
-    return "red.500"
+    return "red.600"
   }, [timeLeftInSeconds, totalTimeInSeconds])
   return (
     <CircularProgress

--- a/src/components/Hooks.tsx
+++ b/src/components/Hooks.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, UseQueryOptions } from "@tanstack/react-query"
 import axios, { AxiosError } from "axios"
 import { compact, concat, flatten } from "lodash"
 import { Uri } from "monaco-editor"
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useParams } from "react-router-dom"
 import { EventSource } from "extended-eventsource"
 import { useKeycloak } from "@react-keycloak/web"
@@ -202,27 +202,45 @@ export const useTask = (userId: string) => {
   return { ...query, submit, timer }
 }
 
-export const useCountdown = (
-  startUnix: number | null,
-  endUnix: number | null,
-) => {
+export const useCountdown = (start: number | null, end: number | null) => {
   const [timeLeftInSeconds, setTimeLeftInSeconds] = useState<number>(0)
+  const [circleValue, setCircleValue] = useState(100)
+  const requestRef = useRef<number | null>(null)
 
   useEffect(() => {
-    const interval = setInterval(() => {
-      if (endUnix === null || startUnix === null) {
-        setTimeLeftInSeconds(0)
-        return
-      }
+    if (start === null || end === null) {
+      setTimeLeftInSeconds(0)
+      setCircleValue(0)
+      return
+    }
 
+    const update = () => {
+      const total = end - start
       const now = Date.now()
-      const timeLeft = endUnix - now
-      setTimeLeftInSeconds(Math.max(0, Math.floor(timeLeft / 1000)))
-    }, 100)
-    return () => clearInterval(interval)
-  }, [endUnix, startUnix])
+      const timeLeft = Math.max(0, end - now)
 
-  return { timeLeftInSeconds }
+      setTimeLeftInSeconds(Math.floor(timeLeft / 1000))
+
+      const progress = Math.max(0, (timeLeft / total) * 100)
+      setCircleValue(progress)
+      if (timeLeft > 0) {
+        requestRef.current = requestAnimationFrame(update)
+      } else {
+        requestRef.current = null
+      }
+    }
+
+    update() // only called initially or when startUnix or endUnix changes
+
+    return () => {
+      if (requestRef.current) {
+        cancelAnimationFrame(requestRef.current)
+        requestRef.current = null
+      }
+    }
+  }, [start, end])
+
+  return { timeLeftInSeconds, circleValue }
 }
 
 export const useTimeframeFromSSE = () => {

--- a/src/components/Hooks.tsx
+++ b/src/components/Hooks.tsx
@@ -202,19 +202,25 @@ export const useTask = (userId: string) => {
   return { ...query, submit, timer }
 }
 
-export const useCountdown = (startUnix: number, endUnix: number) => {
-  const [timeLeftInSeconds, setTimeLeftInSeconds] = useState<number>(
-    endUnix - startUnix,
-  )
+export const useCountdown = (
+  startUnix: number | null,
+  endUnix: number | null,
+) => {
+  const [timeLeftInSeconds, setTimeLeftInSeconds] = useState<number>(0)
 
   useEffect(() => {
     const interval = setInterval(() => {
+      if (endUnix === null || startUnix === null) {
+        setTimeLeftInSeconds(0)
+        return
+      }
+
       const now = Date.now()
       const timeLeft = endUnix - now
       setTimeLeftInSeconds(Math.max(0, Math.floor(timeLeft / 1000)))
     }, 100)
     return () => clearInterval(interval)
-  }, [endUnix])
+  }, [endUnix, startUnix])
 
   return { timeLeftInSeconds }
 }


### PR DESCRIPTION
#77 -> digits no longer "jump around"
#75 Colors adjusted and threshold for color change improved
#76 Timer animation is now smooth. This one was rather tricky and we will need to test that in a live deployment to see if we can really use it or not. `requestAnimationFrame()` only works properly in one tab, as browsers throtle the FPS of tabs/windows running in the background. So testing it locally is rather hard. We'll have to see how it behaves once its deployed.  