### PR TITLE
121 - example reset improvements

### DIFF
--- a/src/pages/Course.tsx
+++ b/src/pages/Course.tsx
@@ -67,7 +67,6 @@ export default function Course() {
     course.examples,
     (e) => e.status === "Active" || e.status === "Interactive",
   )
-  console.log(activeExamples)
   const nrOfSolvedExampels = activeExamples.reduce(
     (total, example) => total + example.points,
     0,

--- a/src/pages/Course.tsx
+++ b/src/pages/Course.tsx
@@ -15,32 +15,32 @@ import {
   Tag,
   TagLabel,
   TagLeftIcon,
-  Text,
   Tbody,
   Td,
+  Text,
   Tr,
   VStack,
   Wrap,
 } from "@chakra-ui/react"
+import { format, parseISO } from "date-fns"
+import { de, enUS } from "date-fns/locale"
+import { get, groupBy, keys, omit } from "lodash"
 import { fork, mapEntries, objectify } from "radash"
-import CourseController from "./CourseController"
-import React, { useState } from "react"
+import { useState } from "react"
 import { DayPicker } from "react-day-picker"
-import { enUS, de } from "date-fns/locale"
-import { AiOutlineTeam, AiOutlineClockCircle } from "react-icons/ai"
+import { useTranslation } from "react-i18next"
+import { AiOutlineClockCircle, AiOutlineTeam } from "react-icons/ai"
 import { BsFillCircleFill } from "react-icons/bs"
 import { FcAlarmClock, FcIdea, FcLock, FcPlanner } from "react-icons/fc"
+import { HiOutlineCalendarDays } from "react-icons/hi2"
 import { Link, useOutletContext } from "react-router-dom"
 import { Detail, EventBox } from "../components/Buttons"
-import { CourseAvatar } from "../components/Icons"
-import { TimeCountDown, ScoreBar } from "../components/Statistics"
 import { useCourse } from "../components/Hooks"
-import { get, groupBy, keys, omit } from "lodash"
-import { format, parseISO } from "date-fns"
-import { HiOutlineCalendarDays } from "react-icons/hi2"
+import { CourseAvatar } from "../components/Icons"
+import { ScoreBar, TimeCountDown } from "../components/Statistics"
 import { formatDateRange } from "../components/Util"
+import CourseController from "./CourseController"
 import CourseCreator from "./CourseCreator"
-import { useTranslation } from "react-i18next"
 
 export default function Course() {
   const { i18n, t } = useTranslation()
@@ -67,7 +67,7 @@ export default function Course() {
     course.examples,
     (e) => e.status === "Active" || e.status === "Interactive",
   )
-
+  console.log(activeExamples)
   const nrOfSolvedExampels = activeExamples.reduce(
     (total, example) => total + example.points,
     0,
@@ -177,38 +177,40 @@ export default function Course() {
         </VStack>
       </GridItem>
       <GridItem as={Stack} layerStyle="container" p={0} spacing={4}>
-        <TableContainer layerStyle="segment">
-          <HStack>
-            <Icon as={FcIdea} boxSize={6} />
-            <Heading fontSize="2xl">{t("Lecture Examples")}</Heading>
-          </HStack>
-          <Divider borderColor="gray.300" my={4} />
-          <Table>
-            <Tbody>
-              <Tr key={course.slug}>
-                {" "}
-                {/* replace this with something better*/}
-                <Td>
-                  <VStack>
-                    <Heading fontSize="lg">{t("Examples")}</Heading>
-                  </VStack>
-                </Td>
-                <Td w="17em" maxW="17em"></Td>
-                <Td w="12em" maxW="12em"></Td>
-                <Td w="10em" maxW="13em">
-                  <Button
-                    w="full"
-                    colorScheme="green"
-                    as={Link}
-                    to={"examples"}
-                  >
-                    {nrOfSolvedExampels ? t("Continue") : t("Examples")}
-                  </Button>
-                </Td>
-              </Tr>
-            </Tbody>
-          </Table>
-        </TableContainer>
+        {isSupervisor || activeExamples.length > 0 ? (
+          <TableContainer layerStyle="segment">
+            <HStack>
+              <Icon as={FcIdea} boxSize={6} />
+              <Heading fontSize="2xl">{t("Lecture Examples")}</Heading>
+            </HStack>
+            <Divider borderColor="gray.300" my={4} />
+
+            <Table>
+              <Tbody>
+                <Tr key={course.slug}>
+                  <Td>
+                    <VStack>
+                      <Heading fontSize="lg">{t("Examples")}</Heading>
+                    </VStack>
+                  </Td>
+                  <Td w="17em" maxW="17em"></Td>
+                  <Td w="12em" maxW="12em"></Td>
+                  <Td w="10em" maxW="13em">
+                    <Button
+                      w="full"
+                      colorScheme="green"
+                      as={Link}
+                      to={"examples"}
+                    >
+                      {nrOfSolvedExampels ? t("Continue") : t("Examples")}
+                    </Button>
+                  </Td>
+                </Tr>
+              </Tbody>
+            </Table>
+          </TableContainer>
+        ) : null}
+
         {!!upcomingAssignments.length && (
           <TableContainer layerStyle="segment">
             <HStack>

--- a/src/pages/Examples.tsx
+++ b/src/pages/Examples.tsx
@@ -20,7 +20,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query"
 import { TFunction } from "i18next"
 import { fork } from "radash"
-import React, { useEffect, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { AiOutlineGlobal, AiOutlineInfoCircle } from "react-icons/ai"
 import { FcPlanner, FcTodoList } from "react-icons/fc"
@@ -82,11 +82,14 @@ export const ExamplesCard: React.FC<{
     fetchAllSubmissionCounts()
   }, [courseSlug, examples, isSupervisor, queryClient])
 
-  const derivedExamples =
-    examplesWithSubmissionCount ??
-    (examples as (TaskOverview & {
-      submissionCount: number
-    })[])
+  const derivedExamples = useMemo(() => {
+    return (
+      examplesWithSubmissionCount ??
+      (examples as (TaskOverview & {
+        submissionCount: number
+      })[])
+    )
+  }, [examples, examplesWithSubmissionCount])
 
   if (!examples || examples.length === 0)
     return (

--- a/src/pages/PrivateDashboard.tsx
+++ b/src/pages/PrivateDashboard.tsx
@@ -423,7 +423,8 @@ const ExampleTimeControler: React.FC<{
 export function PrivateDashboard() {
   const { publish } = usePublish()
   const { terminate } = useTerminate()
-  const { data: fetchedSubmissions } = useStudentSubmissions()
+  const { data: fetchedSubmissions, refetch: refetchStudentSubmissions } =
+    useStudentSubmissions()
   const { resetExample } = useResetExample()
   const [durationInSeconds, setDurationInSeconds] = useState<number>(150)
   const [exampleState, setExampleState] = useState<ExampleState | null>(null)
@@ -434,7 +435,10 @@ export function PrivateDashboard() {
   const currentLanguage = i18n.language
   const { user } = useOutletContext<UserContext>()
   const { data: example } = useExample(user.email)
-  const { data: initialExampleInformation } = useGeneralExampleInformation()
+  const {
+    data: initialExampleInformation,
+    refetch: refetchInitialExampleInformation,
+  } = useGeneralExampleInformation()
   const { timeFrameFromEvent } = useTimeframeFromSSE()
   const durationAsString = useMemo(() => {
     return formatSeconds(durationInSeconds || 0)
@@ -484,10 +488,16 @@ export function PrivateDashboard() {
     try {
       await resetExample()
       setExampleState("unpublished")
+      refetchInitialExampleInformation()
+      refetchStudentSubmissions()
     } catch (e) {
       console.log("Error resetting example: ", e)
     }
-  }, [resetExample])
+  }, [
+    refetchInitialExampleInformation,
+    refetchStudentSubmissions,
+    resetExample,
+  ])
 
   const [derivedStartDate, derivedEndDate] = useMemo(() => {
     if (!example) {

--- a/src/pages/PublicDashboard.tsx
+++ b/src/pages/PublicDashboard.tsx
@@ -87,7 +87,7 @@ export function PublicDashboard() {
     ) {
       return 100
     } else {
-      return numberOfStudentsWhoSubmitted / participantsOnline
+      return (numberOfStudentsWhoSubmitted / participantsOnline) * 100
     }
   }, [example, exampleInformation])
 

--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -115,6 +115,12 @@ export default function Task({ type }: { type: "task" | "example" }) {
     submission?.files?.find((s) => s.taskFileId === file.id)?.content ||
     file.template
 
+  useEffect(() => {
+    if (!isAssistant && task && task.status === "Planned") {
+      navigate("../")
+    }
+  }, [task, isAssistant, navigate])
+
   const [derivedStartDate, derivedEndDate] = useMemo(() => {
     if (!task) {
       return [null, null]


### PR DESCRIPTION
- fixes #119 -> replaced icon with the one used in private dashboard and fetching number of submissions (if supervisor) 
- fixes #121 -> refetches exampleInformation and submissions upon resetting the example -> back to proper initial state. Further more, students can no longer acceess unpublished examples.  