### PR TITLE
FIX: File changes no longer lost when changing from one file to another 

### DIFF
--- a/src/pages/Task.tsx
+++ b/src/pages/Task.tsx
@@ -248,7 +248,7 @@ export default function Task({ type }: { type: "task" | "example" }) {
       }
     }
 
-    return currentFile?.content || currentFile?.template || ""
+    return currentFile?.content || currentFile?.template
   }, [pendingSubmissions, task, currentFile, type])
 
   useEffect(() => {


### PR DESCRIPTION
In short, we now save the content of the current file to `editableFiles` before we switch to the other file we clicked on in either the tabs or in the file tree. 

While this fixes the problem of loosing content when switching between files, there was another bug that would lead to some files being reverted to the template if they were not viewed in the editor between submissions/runs. I explained the bug and solution in the commit message, but i paste it here again for convenience:


### [fixes unable to retreive data for not currently displaye files bug](https://github.com/mp-access/Frontend-Re/commit/bee3b206cc144f1542634763f09109d0b364823f)

This change fixes another bug where unsaved content for files not actively visible in the editor was lost after a submission, which caused them revert to their template content.

The Monaco Editor uses the path prop to create and manage unique Model instances. The original getPath function included the submissionId, which was changing on every run/submission:

```typescript
const getPath = (id: number) => `${id}/${user.email}/${submissionId}`
```

When a run/submission was made, submissionId updated and changed the required model path for all files. In that case the Monaco Editor destroyed the old model because it was no longer linked to an active component path.
When we later called editor.getContent(path) for an inactive file, no model existed at the new path, which lead the function to return undefined and wrongly fall back to file.template, overwriting the content from the actual submission.

I checked that the submissionId is only necessary for data fetching and is not required for Monaco's model identity, since we manually set the content of the editor when restoring a specific  implementation based on the submission's content.